### PR TITLE
Theme files support

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -169,7 +169,12 @@ gulp.task('watch', function() {
 gulp.task('exec', function (cb) {
 
 	if (themeName) {
-		exec('php bin/magento dev:source-theme:deploy --locale="' + themesConfig[themeName].locale + '" --area="' + themesConfig[themeName].area + '" --theme="' + themesConfig[themeName].name + '"', function (err, stdout, stderr) {
+		var deployFiles = '';
+		for (var i in themesConfig[themeName].files) {
+			deployFiles += ' ' + themesConfig[themeName].files[i];
+		}
+
+		exec('php bin/magento dev:source-theme:deploy --locale="' + themesConfig[themeName].locale + '" --area="' + themesConfig[themeName].area + '" --theme="' + themesConfig[themeName].name + '" ' + deployFiles, function (err, stdout, stderr) {
 			console.log(stdout);
 			console.log(stderr);
 			cb(err);


### PR DESCRIPTION
At this moment "exec" task runing "dev:source-theme:deploy" without "<file>" parameter so used defaults css/styles-m css/styles-l (https://i.imgur.com/NOER5MY.png). BUT if theme use some custom files - *.less files will not created and we get error in "less" task: "Error: File not found with singular glob: /PATH_TO_ROOT/pub/static/frontend/Magento/blank/en_US/css/email.less"
For example: try to build blank theme.